### PR TITLE
Fixed issue where loop bit is not cleared from previous looping song.

### DIFF
--- a/AsmPlayer/WYZPROPLAY47c_ZX.ASM
+++ b/AsmPlayer/WYZPROPLAY47c_ZX.ASM
@@ -232,9 +232,10 @@ DECODE_SONG:	LD	A,[SONG]
 		INC	DE		;LOOP 1=ON/0=OFF?
 		LD	A,[DE]
 		BIT	0,A
-		JR	Z,NPTJP0
-		LD	HL,INTERR
-		SET	4,[HL]
+	        LD      HL, INTERR
+		RES     4, (HL)                 ; Reset loop bit by default
+	        JR      Z, NPTJP0
+	        SET     4, (HL)                 ; Set loop bit
 
 
 


### PR DESCRIPTION
Problem found by playing a looping song followed by a non-looping song. The loop bit is set by the first song but not reset by the second so the second song also loops. This change resets the loop bit each time a song is played.